### PR TITLE
Fix streaming

### DIFF
--- a/aiofirebase/__init__.py
+++ b/aiofirebase/__init__.py
@@ -58,10 +58,11 @@ class FirebaseHTTP:
     async def stream(self, *, callback, path=None):
         """Hook up to the EventSource stream."""
         url = posixpath.join(self._base_url, path) if path else self._base_url
+        url += '.json'
         headers = {'accept': 'text/event-stream'}
-        async with self._session.get(url, headers=headers) as resp:
+        async with self._session.get(url, headers=headers, timeout=None) as resp:
             while True:
-                await FirebaseHTTP._iterate_over_stream(resp.content.read(), callback)
+                await FirebaseHTTP._iterate_over_stream(resp.content, callback)
 
     @staticmethod
     async def _iterate_over_stream(iterable, callback):
@@ -72,7 +73,7 @@ class FirebaseHTTP:
             if not msg_str:
                 continue
 
-            key, value = msg_str.split(':', 1)
+            key, value = msg_str.split(': ', 1)
 
             if key == 'event' and value == 'cancel':
                 raise StreamCancelled('The requested location is no longer allowed due to security/rules changes.')


### PR DESCRIPTION
In the interest of full disclosure, I did not test this on older versions of aiohttp and will assume it used to work at some point. I am currently on aiohttp v `3.7.4.post0` and the changes I've made produce a working stream.

---

Since `FirebaseHTTP._request` puts `".json"` on the url, it makes sense to also do it in the stream, where it is absolutely needed (if it's not already provided...)

Besides fixing the functionality of the method itself, the additional space character on line 76 is because the event would otherwise be `" put"` for example.

Technically this is a breaking change, but if you're up to date on aiohttp, it was already broken. 🤪